### PR TITLE
multisend: guard array lengths, add tests, and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: install poetry
+        run: pip install poetry
+      - name: install dependencies
+        run: poetry install --no-interaction
+        env:
+          POETRY_HTTP_TIMEOUT: 300
+      - name: pytest
+        run: poetry run pytest tests/ -n auto

--- a/contracts/dao/Multisend.vy
+++ b/contracts/dao/Multisend.vy
@@ -4,6 +4,7 @@
 @author Yield Basis
 @license GNU Affero General Public License v3.0
 @notice Sends tokens if they were not sent yet, single-use only
+@dev For each index k entries users[k] and amounts[k] match by position; i counter follows that index even if a recipient was already paid
 """
 from ethereum.ercs import IERC20
 
@@ -21,7 +22,9 @@ def __init__(token: IERC20):
 
 @external
 def send(users: DynArray[address, 500], amounts: DynArray[uint256, 500]):
-    assert msg.sender == ADMIN  # otherwise someone could set the already_sent!
+    assert msg.sender == ADMIN # otherwise someone could set the already_sent!
+
+    assert len(users) == len(amounts)
 
     i: uint256 = 0
     for user: address in users:

--- a/tests/dao/test_multisend.py
+++ b/tests/dao/test_multisend.py
@@ -1,0 +1,42 @@
+import boa
+
+
+def test_multisend_pays_each_recipient(admin, accounts, token_mock):
+    token = token_mock.deploy('T', 'T', 18)
+    with boa.env.prank(admin):
+        ms = boa.load('contracts/dao/Multisend.vy', token.address)
+    users = accounts[0:3]
+    amounts = [10**18, 2 * 10**18, 3 * 10**18]
+    with boa.env.prank(admin):
+        token._mint_for_testing(admin, 100 * 10**18)
+        token.approve(ms.address, 2**256 - 1)
+        ms.send(users, amounts)
+    assert token.balanceOf(users[0]) == amounts[0]
+    assert token.balanceOf(users[1]) == amounts[1]
+    assert token.balanceOf(users[2]) == amounts[2]
+
+
+def test_multisend_rejects_mismatched_lengths(admin, accounts, token_mock):
+    token = token_mock.deploy('T', 'T', 18)
+    with boa.env.prank(admin):
+        ms = boa.load('contracts/dao/Multisend.vy', token.address)
+    with boa.env.prank(admin):
+        token._mint_for_testing(admin, 100 * 10**18)
+        token.approve(ms.address, 2**256 - 1)
+    with boa.reverts():
+        with boa.env.prank(admin):
+            ms.send([accounts[0], accounts[1]], [10**18])
+
+
+def test_multisend_index_pairs_by_user_position(admin, accounts, token_mock):
+    token = token_mock.deploy('T', 'T', 18)
+    with boa.env.prank(admin):
+        ms = boa.load('contracts/dao/Multisend.vy', token.address)
+    a, b, c = accounts[0], accounts[1], accounts[2]
+    with boa.env.prank(admin):
+        token._mint_for_testing(admin, 10**30)
+        token.approve(ms.address, 2**256 - 1)
+        ms.send([a, b], [10**18, 10**18])
+        ms.send([a, c], [10**36, 5 * 10**18])
+    assert token.balanceOf(a) == 10**18
+    assert token.balanceOf(c) == 5 * 10**18


### PR DESCRIPTION
﻿## Summary

- Assert `len(users) == len(amounts)` in `Multisend.send` so mismatched arrays cannot read past `amounts` or confuse operators.
- Document index pairing in `@dev` when some recipients were already paid.
- Add Titanoboa tests for Multisend (payouts, length revert, index alignment across two batches).
- Add GitHub Actions workflow running `pytest tests/ -n auto` (flake8 omitted: upstream already has violations in tests/scripts).

made by mooncitydev
